### PR TITLE
Fix HTTP reading when Range request is not supported

### DIFF
--- a/src/main/java/bgzf4j/seekablestream/SeekableHTTPStream.java
+++ b/src/main/java/bgzf4j/seekablestream/SeekableHTTPStream.java
@@ -117,6 +117,9 @@ public class SeekableHTTPStream extends SeekableStream {
         if (len == 0) {
             return 0;
         }
+        if (position == contentLength) {
+            return -1;
+        }
 
         HttpURLConnection connection = null;
         InputStream is = null;


### PR DESCRIPTION
This PR fixes the infinite loop bug described in chrovis/cljam#259.

When a HTTP server does not support a Range request header, `SeekableHTTPStream.read` never returns `-1` and causes the infinite loop.

I have added a EOF check using `position` variable in `SeekableHTTPStream`. That is the same way as 
current original [`SeekableHTTPStream`](https://github.com/samtools/htsjdk/blob/f461401e38fe95362a6d3c5afd8b592964b4bd29/src/main/java/htsjdk/samtools/seekablestream/SeekableHTTPStream.java#L106).